### PR TITLE
Adds optional project-id to the credentials from the provider

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   call-inclusive-naming-check:
     name: Inclusive naming
-    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@main
     with:
       fail-on-error: "true"
 
@@ -14,5 +14,5 @@ jobs:
     name: Lint Unit
     uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
     with:
-      python: "['3.8', '3.9', '3.10', '3.11']"
+      python: "['3.8', '3.10', '3.12']"
       

--- a/ops/ops/interface_openstack_integration/model.py
+++ b/ops/ops/interface_openstack_integration/model.py
@@ -40,6 +40,7 @@ class Data(BaseModel):
     subnet_id: Json[Optional[str]]
     trust_device_path: Json[Optional[bool]]
     version: Json[Optional[int]]
+    project_id: Json[Optional[str]]
 
     @validator("endpoint_tls_ca")
     def must_be_b64_cert(cls, s: Json[str]):
@@ -63,6 +64,8 @@ class Data(BaseModel):
             "domain-name": self.user_domain_name,
             "tenant-domain-name": self.project_domain_name,
         }
+        if self.project_id:
+            config["Global"]["project-id"] = self.project_id
         if self.endpoint_tls_ca:
             config["Global"]["ca-file"] = "/etc/config/endpoint-ca.cert"
 

--- a/ops/tests/data/cloud_conf.ini
+++ b/ops/tests/data/cloud_conf.ini
@@ -6,6 +6,7 @@ password = superSecret
 tenant-name = admin
 domain-name = user
 tenant-domain-name = user
+project-id = 01234567890123456789012345678901
 ca-file = /etc/config/endpoint-ca.cert
 
 [LoadBalancer]

--- a/ops/tests/data/openstack_integration_data.yaml
+++ b/ops/tests/data/openstack_integration_data.yaml
@@ -10,6 +10,7 @@ lb_method: '"ROUND_ROBIN"'
 manage_security_groups: "false"
 password: '"superSecret"'
 project_domain_name: '"user"'
+project_id: '"01234567890123456789012345678901"'
 project_name: '"admin"'
 region: '"myRegion"'
 subnet_id: '""'

--- a/provides.py
+++ b/provides.py
@@ -98,7 +98,8 @@ class IntegrationRequest:
                         project_domain_name,
                         project_name,
                         endpoint_tls_ca,
-                        version=None):
+                        version=None,
+                        project_id=None):
         """
         Set the credentials for this request.
         """
@@ -109,6 +110,7 @@ class IntegrationRequest:
             'password': password,
             'user_domain_name': user_domain_name,
             'project_domain_name': project_domain_name,
+            'project_id': project_id,
             'project_name': project_name,
             'endpoint_tls_ca': endpoint_tls_ca,
             'version': version,

--- a/requires.py
+++ b/requires.py
@@ -113,6 +113,7 @@ class OpenStackIntegrationRequires(Endpoint):
             self.password,
             self.user_domain_name,
             self.project_domain_name,
+            self.project_id,
             self.project_name,
             self.endpoint_tls_ca,
             self.subnet_id,
@@ -164,6 +165,13 @@ class OpenStackIntegrationRequires(Endpoint):
         The project domain name.
         """
         return self._received['project_domain_name']
+
+    @property
+    def project_id(self):
+        """
+        The project id.
+        """
+        return self._received['project_id']
 
     @property
     def project_name(self):


### PR DESCRIPTION
## Overview
Addresses [LP#2075524](https://bugs.launchpad.net/charm-openstack-cloud-controller/+bug/2075524) by adding `PROJECT_ID` sharing over the openstack-integrator relation

### Details
* In some cases, the project-id is necessary to be shared across the cluster as part of the o7k credentials. 

