### PR TITLE
Use upstream CCM docs to build the cloud_config including many new fields

### DIFF
--- a/ops/ops/interface_openstack_integration/model.py
+++ b/ops/ops/interface_openstack_integration/model.py
@@ -29,6 +29,8 @@ class Data(BaseModel):
 
     # Optional config
     bs_version: Json[Optional[str]]
+    domain_id: Json[Optional[str]] = None
+    domain_name: Json[Optional[str]] = None
     endpoint_tls_ca: Json[Optional[str]]
     floating_network_id: Json[Optional[str]]
     has_octavia: Json[Optional[bool]]
@@ -36,11 +38,13 @@ class Data(BaseModel):
     internal_lb: Json[Optional[bool]]
     lb_enabled: Json[Optional[bool]]
     lb_method: Json[Optional[str]]
+    project_id: Json[Optional[str]] = None
+    project_domain_id: Json[Optional[str]] = None
     manage_security_groups: Json[Optional[bool]]
     subnet_id: Json[Optional[str]]
     trust_device_path: Json[Optional[bool]]
-    version: Json[Optional[int]]
-    project_id: Json[Optional[str]]
+    user_domain_id: Json[Optional[str]] = None
+    version: Json[Optional[int]] = None
 
     @validator("endpoint_tls_ca")
     def must_be_b64_cert(cls, s: Json[str]):
@@ -53,53 +57,72 @@ class Data(BaseModel):
 
     @property
     def cloud_config(self) -> str:  # noqa: C901
-        """Render as an openstack cloud config ini."""
-        config = configparser.ConfigParser()
-        config["Global"] = {
-            "auth-url": self.auth_url,
-            "region": self.region,
-            "username": self.username,
-            "password": self.password.get_secret_value(),
-            "tenant-name": self.project_name,
-            "domain-name": self.user_domain_name,
-            "tenant-domain-name": self.project_domain_name,
-        }
-        if self.project_id:
-            config["Global"]["project-id"] = self.project_id
-        if self.endpoint_tls_ca:
-            config["Global"]["ca-file"] = "/etc/config/endpoint-ca.cert"
+        """Render as an openstack cloud config ini.
 
-        config["LoadBalancer"] = {}
+        https://github.com/kubernetes/cloud-provider-openstack/blob/75b1fbb91a2566a869b8922ad62e1c03ab5e6eac/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#global
+
+        """
+        _global, _loadbalancer, _blockstorage = {}, {}, {}
+        if self.auth_url:
+            _global["auth-url"] = self.auth_url
+        if self.endpoint_tls_ca:
+            _global["ca-file"] = "/etc/config/endpoint-ca.cert"
+        if self.username:
+            _global["username"] = self.username
+        if self.password:
+            _global["password"] = self.password.get_secret_value()
+        if self.region:
+            _global["region"] = self.region
+        if self.domain_id:
+            _global["domain-id"] = self.domain_id
+        if self.domain_name:
+            _global["domain-name"] = self.domain_name
+        if self.project_id:
+            _global["tenant-id"] = self.project_id
+        if self.project_name:
+            _global["tenant-name"] = self.project_name
+        if self.project_domain_id:
+            _global["tenant-domain-id"] = self.project_domain_id
+        if self.project_domain_name:
+            _global["tenant-domain-name"] = self.project_domain_name
+        if self.user_domain_id:
+            _global["user-domain-id"] = self.user_domain_id
+        if self.user_domain_name:
+            _global["user-domain-name"] = self.user_domain_name
+
         if not self.lb_enabled:
-            config["LoadBalancer"]["enabled"] = "false"
+            _loadbalancer["enabled"] = "false"
         if self.has_octavia in (True, None):
             # Newer integrator charm will detect whether underlying OpenStack has
             # Octavia enabled so we can set this intelligently. If we're still
             # related to an older integrator, though, default to assuming Octavia
             # is available.
-            config["LoadBalancer"]["use-octavia"] = "true"
+            _loadbalancer["use-octavia"] = "true"
         else:
-            config["LoadBalancer"]["use-octavia"] = "false"
-            config["LoadBalancer"]["lb-provider"] = "haproxy"
+            _loadbalancer["use-octavia"] = "false"
+            _loadbalancer["lb-provider"] = "haproxy"
         if _s := self.subnet_id:
-            config["LoadBalancer"]["subnet-id"] = _s
+            _loadbalancer["subnet-id"] = _s
         if _s := self.floating_network_id:
-            config["LoadBalancer"]["floating-network-id"] = _s
+            _loadbalancer["floating-network-id"] = _s
         if _s := self.lb_method:
-            config["LoadBalancer"]["lb-method"] = _s
+            _loadbalancer["lb-method"] = _s
         if self.internal_lb:
-            config["LoadBalancer"]["internal-lb"] = "true"
+            _loadbalancer["internal-lb"] = "true"
         if self.manage_security_groups:
-            config["LoadBalancer"]["manage-security-groups"] = "true"
+            _loadbalancer["manage-security-groups"] = "true"
 
-        config["BlockStorage"] = {}
         if _os := self.bs_version:
-            config["BlockStorage"]["bs-version"] = _os
+            _blockstorage["bs-version"] = _os
         if self.trust_device_path:
-            config["BlockStorage"]["trust-device-path"] = "true"
+            _blockstorage["trust-device-path"] = "true"
         if self.ignore_volume_az:
-            config["BlockStorage"]["ignore-volume-az"] = "true"
+            _blockstorage["ignore-volume-az"] = "true"
 
+        config = configparser.ConfigParser()
+        config["Global"] = _global
+        config["LoadBalancer"] = _loadbalancer
+        config["BlockStorage"] = _blockstorage
         with contextlib.closing(io.StringIO()) as sio:
             config.write(sio)
             output_text = sio.getvalue()

--- a/ops/tests/data/cloud_conf.ini
+++ b/ops/tests/data/cloud_conf.ini
@@ -1,13 +1,17 @@
 [Global]
 auth-url = https://5.5.5.5/v3/
-region = myRegion
+ca-file = /etc/config/endpoint-ca.cert
 username = admin
 password = superSecret
+region = myRegion
+domain-id = 23456789012345678901234567890123
+domain-name = admin_domain
+tenant-id = 01234567890123456789012345678901
 tenant-name = admin
-domain-name = user
-tenant-domain-name = user
-project-id = 01234567890123456789012345678901
-ca-file = /etc/config/endpoint-ca.cert
+tenant-domain-id = 12345678901234567890123456789012
+tenant-domain-name = project_domain
+user-domain-id = 90123456789012345678901234567890
+user-domain-name = user
 
 [LoadBalancer]
 use-octavia = true

--- a/ops/tests/data/openstack_integration_data.yaml
+++ b/ops/tests/data/openstack_integration_data.yaml
@@ -9,12 +9,16 @@ lb_enabled: "true"
 lb_method: '"ROUND_ROBIN"'
 manage_security_groups: "false"
 password: '"superSecret"'
-project_domain_name: '"user"'
+domain_name: '"admin_domain"'
+domain_id: '"23456789012345678901234567890123"'
+project_domain_id: '"12345678901234567890123456789012"'
+project_domain_name: '"project_domain"'
 project_id: '"01234567890123456789012345678901"'
 project_name: '"admin"'
 region: '"myRegion"'
 subnet_id: '""'
 trust_device_path: "null"
 user_domain_name: '"user"'
+user_domain_id: '"90123456789012345678901234567890"'
 username: '"admin"'
 version: '"3"'

--- a/provides.py
+++ b/provides.py
@@ -98,8 +98,14 @@ class IntegrationRequest:
                         project_domain_name,
                         project_name,
                         endpoint_tls_ca,
+                        *_,
+                        domain_id=None,
+                        domain_name=None,
+                        project_id=None,
+                        project_domain_id=None,
+                        user_domain_id=None,
                         version=None,
-                        project_id=None):
+            ):
         """
         Set the credentials for this request.
         """
@@ -108,11 +114,15 @@ class IntegrationRequest:
             'region': region,
             'username': username,
             'password': password,
-            'user_domain_name': user_domain_name,
+            'domain_id': domain_id,
+            'domain_name': domain_name,
+            'endpoint_tls_ca': endpoint_tls_ca,
             'project_domain_name': project_domain_name,
+            'project_domain_id': project_domain_id,
             'project_id': project_id,
             'project_name': project_name,
-            'endpoint_tls_ca': endpoint_tls_ca,
+            'user_domain_id': user_domain_id,
+            'user_domain_name': user_domain_name,
             'version': version,
         })
 

--- a/requires.py
+++ b/requires.py
@@ -111,8 +111,12 @@ class OpenStackIntegrationRequires(Endpoint):
             self.region,
             self.username,
             self.password,
+            self.domain_id,
+            self.domain_name,
             self.user_domain_name,
+            self.user_domain_id,
             self.project_domain_name,
+            self.project_domain_id,
             self.project_id,
             self.project_name,
             self.endpoint_tls_ca,
@@ -130,6 +134,20 @@ class OpenStackIntegrationRequires(Endpoint):
         The authentication endpoint URL.
         """
         return self._received['auth_url']
+
+    @property
+    def domain_id(self):
+        """
+        The domain-id.
+        """
+        return self._received['domain_id']
+    
+    @property
+    def domain_name(self):
+        """
+        The domain name.
+        """
+        return self._received['domain_name']
 
     @property
     def region(self):
@@ -153,11 +171,25 @@ class OpenStackIntegrationRequires(Endpoint):
         return self._received['password']
 
     @property
+    def user_domain_id(self):
+        """
+        The user domain id.
+        """
+        return self._received['user_domain_id']
+
+    @property
     def user_domain_name(self):
         """
         The user domain name.
         """
         return self._received['user_domain_name']
+
+    @property
+    def project_domain_id(self):
+        """
+        The project-domain-id.
+        """
+        return self._received['project_domain_id']
 
     @property
     def project_domain_name(self):
@@ -169,7 +201,7 @@ class OpenStackIntegrationRequires(Endpoint):
     @property
     def project_id(self):
         """
-        The project id.
+        The project-id.
         """
         return self._received['project_id']
 


### PR DESCRIPTION
## Overview

Adds support for many more fields listed in [Openstack CCM **cloud_config**](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#global)

## Details
Changes in #16 didn't really go far enough in added enough fields to get some openstack authentication to go for.  Let's go full on and support many more possible fields for openstack authentication. 
* structure of the cloud_config file is now ordered alphabetically
* adds fields `domain_id`, `domain_name`, `project_domain_id`, `user_domain_id`