### PR TITLE
Support sharing the proxy-config via o7k-interface relation

### DIFF
--- a/docs/provides.md
+++ b/docs/provides.md
@@ -106,13 +106,14 @@ IntegrationRequest.set_block_storage_config(bs_version, trust_device_path,
 
 Set the block storage config for this request.
 
-<h2 id="provides.IntegrationRequest.get_proxy_config">get_proxy_config</h2>
+<h2 id="provides.IntegrationRequest.proxy_config">proxy_config</h2>
 
 ```python
-IntegrationRequest.get_proxy_config() -> Dict[str, str]
+@property
+IntegrationRequest.proxy_config() -> Dict[str, str]
 ```
 
-Retrieve the proxy_config previously set by the provider side of the charm.
+Retrieve the `proxy_config` currently set by the provider side of the charm.
 
 <h2 id="provides.IntegrationRequest.set_proxy_config">set_proxy_config</h2>
 

--- a/docs/provides.md
+++ b/docs/provides.md
@@ -106,3 +106,18 @@ IntegrationRequest.set_block_storage_config(bs_version, trust_device_path,
 
 Set the block storage config for this request.
 
+<h2 id="provides.IntegrationRequest.get_proxy_config">get_proxy_config</h2>
+
+```python
+IntegrationRequest.get_proxy_config() -> Dict[str, str]
+```
+
+Retrieve the proxy_config previously set by the provider side of the charm.
+
+<h2 id="provides.IntegrationRequest.set_proxy_config">set_proxy_config</h2>
+
+```python
+IntegrationRequest.set_proxy_config() -> Dict[str, str]
+```
+
+Share the proxy_config for openstack endpoints from the provider side of the relation.

--- a/docs/requires.md
+++ b/docs/requires.md
@@ -158,3 +158,13 @@ The username.
 
 Optional version number for the APIs or None.
 
+
+<h2 id="requires.OpenStackIntegrationRequires.proxy_config">proxy_config</h2>
+
+```python
+@property
+OpenStackIntegrationRequires.proxy_config() -> Dict[str, str]
+```
+
+Optional `proxy_config` used to indicate to the application proxy details
+necessary to reach the openstack endpoints.

--- a/ops/ops/interface_openstack_integration/model.py
+++ b/ops/ops/interface_openstack_integration/model.py
@@ -10,7 +10,7 @@ import binascii
 import configparser
 import contextlib
 import io
-from typing import Optional
+from typing import Dict, Optional
 
 from pydantic import BaseModel, Json, SecretStr, validator
 
@@ -40,6 +40,7 @@ class Data(BaseModel):
     lb_method: Json[Optional[str]]
     project_id: Json[Optional[str]] = None
     project_domain_id: Json[Optional[str]] = None
+    proxy_config: Json[Optional[Dict[str, str]]] = None
     manage_security_groups: Json[Optional[bool]]
     subnet_id: Json[Optional[str]]
     trust_device_path: Json[Optional[bool]]

--- a/ops/ops/interface_openstack_integration/requires.py
+++ b/ops/ops/interface_openstack_integration/requires.py
@@ -7,7 +7,7 @@ is still using the Reactive Charm framework self.
 """
 import base64
 import logging
-from typing import Optional
+from typing import Dict, Optional
 
 from backports.cached_property import cached_property
 from ops.charm import CharmBase, RelationBrokenEvent
@@ -108,3 +108,15 @@ class OpenstackIntegrationRequirer(Object):
             if data.endpoint_tls_ca:
                 return data.endpoint_tls_ca.encode()
         return None
+
+    @property
+    def proxy_config(self) -> Dict[str, str]:
+        """Return proxy_config from integrator relation."""
+        if self.is_ready and (data := self._data):
+            config = data.proxy_config
+        else:
+            config = {}
+
+        if not config or not isinstance(config, dict):
+            return {}
+        return {k: (v or "") for k, v in config.items()}

--- a/ops/ops/interface_openstack_integration/requires.py
+++ b/ops/ops/interface_openstack_integration/requires.py
@@ -112,11 +112,7 @@ class OpenstackIntegrationRequirer(Object):
     @property
     def proxy_config(self) -> Dict[str, str]:
         """Return proxy_config from integrator relation."""
+        config = None
         if self.is_ready and (data := self._data):
             config = data.proxy_config
-        else:
-            config = {}
-
-        if not config or not isinstance(config, dict):
-            return {}
-        return {k: (v or "") for k, v in config.items()}
+        return config or {}

--- a/provides.py
+++ b/provides.py
@@ -161,9 +161,10 @@ class IntegrationRequest:
             'ignore_volume_az': ignore_volume_az,
         })
 
-    def get_proxy_config(self) -> Dict[str, str]:
+    @property
+    def proxy_config(self) -> Dict[str, str]:
         """
-        Get the proxy config for this request.
+        Get the proxy config answered on this request.
 
         if `proxy_config` is not set, return an empty dict.
         """

--- a/provides.py
+++ b/provides.py
@@ -12,6 +12,7 @@ The flags that are set by the provides side of this interface are:
 """
 
 from operator import attrgetter
+from typing import Dict
 
 from charms.reactive import Endpoint
 from charms.reactive import when
@@ -109,7 +110,7 @@ class IntegrationRequest:
         """
         Set the credentials for this request.
         """
-        self._unit.relation.to_publish.update({
+        self._to_publish.update({
             'auth_url': auth_url,
             'region': region,
             'username': username,
@@ -137,7 +138,7 @@ class IntegrationRequest:
         """
         Set the load-balancer-as-a-service config for this request.
         """
-        self._unit.relation.to_publish.update({
+        self._to_publish.update({
             'subnet_id': subnet_id,
             'floating_network_id': floating_network_id,
             'lb_method': lb_method,
@@ -154,10 +155,29 @@ class IntegrationRequest:
         """
         Set the block storage config for this request.
         """
-        self._unit.relation.to_publish.update({
+        self._to_publish.update({
             'bs_version': bs_version,
             'trust_device_path': trust_device_path,
             'ignore_volume_az': ignore_volume_az,
+        })
+
+    def get_proxy_config(self) -> Dict[str, str]:
+        """
+        Get the proxy config for this request.
+
+        if `proxy_config` is not set, return an empty dict.
+        """
+        data = self._to_publish.get('proxy_config')
+        if not data or not isinstance(data, dict):
+            return {}
+        return {k: (v or "") for k, v  in data.items()}
+
+    def set_proxy_config(self, proxy_config: Dict[str, str]):
+        """
+        Set the proxy config for this request.
+        """
+        self._to_publish.update({
+            'proxy_config': proxy_config,
         })
 
     @property
@@ -165,4 +185,4 @@ class IntegrationRequest:
         """
         Whether or not credentials have been set via `set_credentials`.
         """
-        return 'credentials' in self._unit.relation.to_publish
+        return 'credentials' in self._to_publish

--- a/requires.py
+++ b/requires.py
@@ -22,6 +22,7 @@ The flags that are set by the requires side of this interface are:
   charm once handled.
 """
 
+from typing import Dict
 
 from charms.reactive import Endpoint
 from charms.reactive import when, when_not
@@ -311,3 +312,11 @@ class OpenStackIntegrationRequires(Endpoint):
         """
         # be careful to ensure a None value is returned as True, for backward compatibility
         return self._received['lb_enabled'] is not False
+
+    @property
+    def proxy_config(self) -> Dict[str, str]:
+        """Return proxy_config from integrator relation."""
+        data = self._received.get('proxy_config') 
+        if not data or not isinstance(data, dict):
+            return {}
+        return {k: (v or "") for k, v  in data.items()}


### PR DESCRIPTION
share the following values over the `openstack-client` relation so that openstack endpoints are contacted through the proxy:

this dictionary will be filled by the `openstack-integrator` with the following env variables useful for proxying to openstack endpoints
`HTTP_PROXY`
`HTTPS_PROXY`
`NO_PROXY`